### PR TITLE
Add autocomplete, explorer, finder, theme, surround and treesitter extensions

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -8,4 +8,5 @@
   "nvim-lspconfig": { "branch": "master", "commit": "8917d2c830e04bf944a699b8c41f097621283828" },
   "nvim-treesitter": { "branch": "master", "commit": "b4138891b3454beeb14eef171c91c92377fcd715" },
   "vscode.nvim": { "branch": "main", "commit": "4a337bbb7e2ca371b614479f86c20c384ff1ad79" }
-}
+  "nvim-treesitter-context": { "branch": "master", "commit": "9c06b115abc57c99cf0aa81dc29490f5001f57a1" },
+  "nvim-treesitter-textobjects": { "branch": "master", "commit": "19a91a38b02c1c28c14e0ba468d20ae1423c39b2" }

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -3,6 +3,7 @@
   "lazy.nvim": { "branch": "main", "commit": "aedcd79811d491b60d0a6577a9c1701063c2a609" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "b9084b1f42f790d6230dc66dbcb6bcc35b148552" },
   "mason.nvim": { "branch": "main", "commit": "dcd0ea30ccfc7d47e879878d1270d6847a519181" },
+  "mini.surround": { "branch": "main", "commit": "af8129efcabe95fc08a233e9f91569829bed031f" },
   "nvim-lint": { "branch": "master", "commit": "8e5920f9ce9f24c283a2e64be5fe58d1d37d1744" },
   "nvim-lspconfig": { "branch": "master", "commit": "8917d2c830e04bf944a699b8c41f097621283828" },
   "nvim-treesitter": { "branch": "master", "commit": "b4138891b3454beeb14eef171c91c92377fcd715" },

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -5,5 +5,6 @@
   "mason.nvim": { "branch": "main", "commit": "dcd0ea30ccfc7d47e879878d1270d6847a519181" },
   "nvim-lint": { "branch": "master", "commit": "8e5920f9ce9f24c283a2e64be5fe58d1d37d1744" },
   "nvim-lspconfig": { "branch": "master", "commit": "8917d2c830e04bf944a699b8c41f097621283828" },
-  "nvim-treesitter": { "branch": "master", "commit": "b4138891b3454beeb14eef171c91c92377fcd715" }
+  "nvim-treesitter": { "branch": "master", "commit": "b4138891b3454beeb14eef171c91c92377fcd715" },
+  "vscode.nvim": { "branch": "main", "commit": "4a337bbb7e2ca371b614479f86c20c384ff1ad79" }
 }

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -11,3 +11,6 @@
   "vscode.nvim": { "branch": "main", "commit": "4a337bbb7e2ca371b614479f86c20c384ff1ad79" }
   "nvim-treesitter-context": { "branch": "master", "commit": "9c06b115abc57c99cf0aa81dc29490f5001f57a1" },
   "nvim-treesitter-textobjects": { "branch": "master", "commit": "19a91a38b02c1c28c14e0ba468d20ae1423c39b2" }
+  "plenary.nvim": { "branch": "master", "commit": "663246936325062427597964d81d30eaa42ab1e4" },
+  "telescope.nvim": { "branch": "master", "commit": "d90956833d7c27e73c621a61f20b29fdb7122709" }
+}

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -1,4 +1,5 @@
 {
+  "carbon.nvim": { "branch": "master", "commit": "9670efb032c4a43c5aa32a0a7ae56afdbf3c275c" },
   "conform.nvim": { "branch": "master", "commit": "d99b75b4aedf0e912f41c5740a7267de739cddac" },
   "lazy.nvim": { "branch": "main", "commit": "aedcd79811d491b60d0a6577a9c1701063c2a609" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "b9084b1f42f790d6230dc66dbcb6bcc35b148552" },

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -5,6 +5,7 @@
   "mason-lspconfig.nvim": { "branch": "main", "commit": "b9084b1f42f790d6230dc66dbcb6bcc35b148552" },
   "mason.nvim": { "branch": "main", "commit": "dcd0ea30ccfc7d47e879878d1270d6847a519181" },
   "mini.surround": { "branch": "main", "commit": "af8129efcabe95fc08a233e9f91569829bed031f" },
+  "mini.completion": { "branch": "main", "commit": "3469773c1280a962bff89c06278007e8aaa30eb5" },
   "nvim-lint": { "branch": "master", "commit": "8e5920f9ce9f24c283a2e64be5fe58d1d37d1744" },
   "nvim-lspconfig": { "branch": "master", "commit": "8917d2c830e04bf944a699b8c41f097621283828" },
   "nvim-treesitter": { "branch": "master", "commit": "b4138891b3454beeb14eef171c91c92377fcd715" },

--- a/nvim/.config/nvim/lua/plugins/autocomplete.lua
+++ b/nvim/.config/nvim/lua/plugins/autocomplete.lua
@@ -1,0 +1,30 @@
+local Autocomplete = {
+	"echasnovski/mini.completion",
+	version = false,
+}
+
+Autocomplete.config = function()
+	require("mini.completion").setup({
+		-- search MiniCompletionSetup for help
+		delay = { completion = 1000, info = 1000, signature = 1000 },
+		window = {
+			info = { height = 7, width = 80, border = "double" },
+			signature = { height = 7, width = 80, border = "none" },
+		},
+		lsp_completion = {
+			-- we use omnifunc and attach it manually in lsp initialisation
+			source_func = "omnifunc",
+			auto_setup = false,
+		},
+		fallback_action = function() end,
+		mappings = {
+			force_twostep = "<C-Space>", -- Force two-step completion
+			force_fallback = "<A-Space>", -- Force fallback completion
+		},
+		-- Whether to set Vim's settings for better experience (modifies
+		-- `shortmess` and `completeopt`)
+		set_vim_settings = true,
+	})
+end
+
+return { Autocomplete }

--- a/nvim/.config/nvim/lua/plugins/explorer.lua
+++ b/nvim/.config/nvim/lua/plugins/explorer.lua
@@ -1,0 +1,9 @@
+local Explorer = { "SidOfc/carbon.nvim" }
+
+Explorer.config = function()
+	require("carbon").setup()
+
+	vim.keymap.set("n", "<leader>e", "<cmd>Fcarbon<CR>")
+end
+
+return { Explorer }

--- a/nvim/.config/nvim/lua/plugins/finder.lua
+++ b/nvim/.config/nvim/lua/plugins/finder.lua
@@ -1,0 +1,29 @@
+local Finder = {
+	"nvim-telescope/telescope.nvim",
+	tag = "0.1.5",
+	dependencies = { "nvim-lua/plenary.nvim" },
+}
+
+Finder.config = function()
+	require("telescope").setup()
+	local builtin = require("telescope.builtin")
+
+	-- File Pickers
+	vim.keymap.set("n", "<leader>ff", builtin.find_files)
+	vim.keymap.set("n", "<leader>fs", builtin.live_grep)
+	vim.keymap.set("n", "<leader>fc", builtin.grep_string)
+
+	-- Vim Pickers
+	vim.keymap.set("n", "<leader>fh", builtin.help_tags)
+
+	-- LSP Pickers
+	vim.keymap.set("n", "<leader>d", builtin.diagnostics)
+	vim.keymap.set("n", "<leader>fo", builtin.lsp_document_symbols)
+	vim.keymap.set("n", "<leader>fO", builtin.lsp_dynamic_workspace_symbols)
+	vim.keymap.set("n", "gr", builtin.lsp_references)
+	vim.keymap.set("n", "gd", builtin.lsp_definitions)
+	vim.keymap.set("n", "gt", builtin.lsp_type_definitions)
+	vim.keymap.set("n", "gi", builtin.lsp_implementations)
+end
+
+return { Finder }

--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -63,19 +63,10 @@ Lsp.config = function()
 			-- See `:help vim.lsp.*` for documentation on any of the below functions
 			local opts = { buffer = ev.buf }
 			vim.keymap.set("n", "gD", vim.lsp.buf.declaration, opts)
-			vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
 			vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
-			vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
 			vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, opts)
-			vim.keymap.set("n", "<leader>wa", vim.lsp.buf.add_workspace_folder, opts)
-			vim.keymap.set("n", "<leader>wr", vim.lsp.buf.remove_workspace_folder, opts)
-			vim.keymap.set("n", "<leader>wl", function()
-				print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
-			end, opts)
-			vim.keymap.set("n", "<leader>D", vim.lsp.buf.type_definition, opts)
 			vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts)
 			vim.keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, opts)
-			vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
 		end,
 	})
 end

--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -57,7 +57,8 @@ Lsp.config = function()
 		group = vim.api.nvim_create_augroup("UserLspConfig", {}),
 		callback = function(ev)
 			-- Enable completion triggered by <c-x><c-o>
-			vim.bo[ev.buf].omnifunc = "v:lua.vim.lsp.omnifunc"
+			-- vim.bo[ev.buf].omnifunc = "v:lua.vim.lsp.omnifunc"
+			vim.bo[ev.buf].omnifunc = "v:lua.MiniCompletion.completefunc_lsp"
 
 			-- Buffer local mappings.
 			-- See `:help vim.lsp.*` for documentation on any of the below functions

--- a/nvim/.config/nvim/lua/plugins/surround.lua
+++ b/nvim/.config/nvim/lua/plugins/surround.lua
@@ -1,0 +1,10 @@
+local Surround = {
+	"echasnovski/mini.surround",
+	version = "*",
+}
+
+Surround.config = function()
+	require("mini.surround").setup()
+end
+
+return { Surround }

--- a/nvim/.config/nvim/lua/plugins/theme.lua
+++ b/nvim/.config/nvim/lua/plugins/theme.lua
@@ -1,0 +1,13 @@
+local Theme = {
+	"Mofiqul/vscode.nvim",
+}
+
+Theme.config = function()
+	local vscode = require("vscode")
+
+	vscode.setup({ style = "dark" })
+
+	vscode.load()
+end
+
+return { Theme }

--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -2,6 +2,10 @@ local Treesitter = {
 	"nvim-treesitter/nvim-treesitter",
 	lazy = false,
 	build = ":TSUpdate",
+	dependencies = {
+		"nvim-treesitter/nvim-treesitter-textobjects",
+		"nvim-treesitter/nvim-treesitter-context",
+	},
 }
 
 Treesitter.config = function()
@@ -21,6 +25,36 @@ Treesitter.config = function()
 			enable = true,
 			additional_vim_regex_highlighting = false,
 		},
+		textobjects = {
+
+			select = {
+				enable = true,
+				lookahead = true, -- Automatically jump forward to textobj, similar to targets.vim
+				keymaps = {
+					-- You can use the capture groups defined in textobjects.scm
+					["ap"] = "@parameter.outer",
+					["ip"] = "@parameter.inner",
+					["af"] = "@function.outer",
+					["if"] = "@function.inner",
+				},
+			},
+			move = {
+				enable = true,
+				set_jumps = true, -- whether to set jumps in the jumplist
+				goto_next_start = {
+					["]f"] = "@function.outer",
+				},
+				goto_previous_start = {
+					["[f"] = "@function.outer",
+				},
+			},
+		},
+	})
+
+	require("treesitter-context").setup({
+		max_lines = 1,
+		trim_scope = "inner",
+		mode = "topline",
 	})
 end
 


### PR DESCRIPTION
Adds the following plugins with minimal configuration:

- mini completion
- carbon
- telescope
- mini surround
- treesitter text objects
- treesitter context

Note that the addition of telescope affects the key bindings inside lsp.lua, and the addition of mini completion affects the omnifunc statement inside lsp.lua.